### PR TITLE
Support parsing hevc codec in MOOV atoms

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const _FTYP = Buffer.from([0x66, 0x74, 0x79, 0x70]); // ftyp
 const _MOOV = Buffer.from([0x6d, 0x6f, 0x6f, 0x76]); // moov
 const _MDHD = Buffer.from([0x6d, 0x64, 0x68, 0x64]); // mdhd
 const _AVCC = Buffer.from([0x61, 0x76, 0x63, 0x43]); // avcC
+const _HVCC = Buffer.from([0x68, 0x76, 0x63, 0x43]); // hvcC
 const _MP4A = Buffer.from([0x6d, 0x70, 0x34, 0x61]); // mp4a
 const _MOOF = Buffer.from([0x6d, 0x6f, 0x6f, 0x66]); // moof
 const _MDAT = Buffer.from([0x6d, 0x64, 0x61, 0x74]); // mdat
@@ -505,10 +506,12 @@ class Mp4Frag extends Transform {
     const mdhdIndex = this._initialization.indexOf(_MDHD);
     const mdhdVersion = this._initialization[mdhdIndex + 4];
     this._timescale = this._initialization.readUInt32BE(mdhdIndex + (mdhdVersion === 0 ? 16 : 24));
-    const videoCodecIndex = this._initialization.indexOf(_AVCC);
+    let index_avc = this._initialization.indexOf(_AVCC);
+    let index_hvc = this._initialization.indexOf(_HVCC);
+    const videoCodecIndex = index_avc !== -1 ? index_avc: index_hvc;
     const audioCodecIndex = this._initialization.indexOf(_MP4A);
     const codecs = [];
-    if (videoCodecIndex !== -1) {
+    if (index_avc !== -1) {
       // todo check for other types of video codecs
       this._videoCodec = `avc1.${this._initialization
         .slice(videoCodecIndex + 5, videoCodecIndex + 8)

--- a/tests/test13.js
+++ b/tests/test13.js
@@ -1,6 +1,6 @@
 'use strict';
 
-console.time('=====> test.js');
+console.time('=====> test13.js');
 
 const assert = require('assert');
 
@@ -91,7 +91,7 @@ ffmpeg.once('error', (error) => {
 ffmpeg.once('exit', (code, signal) => {
   // assert(counter === count, `${counter} !== ${count}`);
   assert(code === 0, `FFMPEG exited with code ${code} and signal ${signal}`);
-  console.timeEnd('=====> test.js');
+  console.timeEnd('=====> test13.js');
 });
 
 ffmpeg.stdio[1].pipe(mp4frag);

--- a/tests/test13.js
+++ b/tests/test13.js
@@ -1,0 +1,97 @@
+'use strict';
+
+console.time('=====> test.js');
+
+const assert = require('assert');
+
+const Mp4Frag = require('../index');
+
+const ffmpegPath = require('../lib/ffmpeg');
+
+const { spawn } = require('child_process');
+
+const frameLimit = 200;
+
+const gop = 10;
+
+const count = Math.ceil(frameLimit / gop); //expected number of segments to be cut from ffmpeg
+
+const scale = 640;
+
+const fps = 10;
+
+let counter = 0;
+
+const params = [
+  /* log info to console */
+  '-loglevel',
+  'quiet',
+  '-stats',
+
+  /* use hardware acceleration if available */
+  '-hwaccel',
+  'auto',
+
+  /* use an artificial video input */
+  //'-re',
+  '-f',
+  'lavfi',
+  '-i',
+  'testsrc=size=1280x720:rate=20',
+
+  /* set output flags */
+  '-an',
+  '-c:v',
+  'libx265',
+  '-movflags',
+  '+frag_keyframe+empty_moov+default_base_moof',
+  '-f',
+  'mp4',
+  '-vf',
+  `fps=${fps},scale=${scale}:-1,format=yuv420p`,
+  '-frames',
+  frameLimit,
+  '-g',
+  gop,
+  '-profile:v',
+  'main',
+  '-level',
+  '2.1',
+  '-crf',
+  '25',
+  '-metadata',
+  'title=test mp4',
+  'pipe:1',
+];
+
+const hlsBase = 'some_HlsBase';
+
+const mp4frag = new Mp4Frag({ hlsPlaylistBase: hlsBase, hlsPlaylistSize: 5 });
+
+mp4frag.once('initialized', (data) => {
+  assert(data.mime === 'video/mp4; codecs="hvc1.1.6.L63.90"', `${data.mime} !== video/mp4; codecs="hvc1.1.6.L63.90"`);
+});
+
+mp4frag.on('segment', (data) => {
+  counter++;
+  //console.log(mp4frag.sequence, data.length, mp4frag.segment.length, mp4frag.getHlsSegment(mp4frag.sequence).length, mp4frag.getHlsNamedSegment(`${hlsBase}${mp4frag.sequence}.m4s`).length);
+});
+
+mp4frag.once('error', (err) => {
+  //error is expected when ffmpeg exits without unpiping
+  console.log('mp4frag error', err.message);
+});
+
+const ffmpeg = spawn(ffmpegPath, params, { stdio: ['ignore', 'pipe', 'inherit'] });
+
+ffmpeg.once('error', (error) => {
+  console.log('ffmpeg error', error);
+});
+
+ffmpeg.once('exit', (code, signal) => {
+  // assert(counter === count, `${counter} !== ${count}`);
+  assert(code === 0, `FFMPEG exited with code ${code} and signal ${signal}`);
+  console.timeEnd('=====> test.js');
+});
+
+ffmpeg.stdio[1].pipe(mp4frag);


### PR DESCRIPTION
Because mp4/fmp4 container support HEVC/H.265 codec and I need `mp4frag` to be able to parse fmp4 segment with HEVC codec for my project , I add a parser to handle this case. I also add a testcase "test13.js" to test that.